### PR TITLE
CC-32183 Backport for fixing missing rating in product view cards.

### DIFF
--- a/src/Spryker/Client/ProductReview/Plugin/Elasticsearch/Query/BulkProductReviewsQueryPlugin.php
+++ b/src/Spryker/Client/ProductReview/Plugin/Elasticsearch/Query/BulkProductReviewsQueryPlugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.

--- a/src/Spryker/Client/ProductReview/ProductReviewClient.php
+++ b/src/Spryker/Client/ProductReview/ProductReviewClient.php
@@ -105,10 +105,10 @@ class ProductReviewClient extends AbstractClient implements ProductReviewClientI
      *
      * @api
      *
-     * @param \Generated\Shared\Transfer\ProductViewTransfer[] $productViewTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
      * @param \Generated\Shared\Transfer\BulkProductReviewSearchRequestTransfer $bulkProductReviewSearchRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\ProductViewTransfer[]
+     * @return array<int, \Generated\Shared\Transfer\ProductViewTransfer>
      */
     public function expandProductViewBulkWithProductReviewData(
         array $productViewTransfers,

--- a/src/Spryker/Client/ProductReview/ProductReviewClient.php
+++ b/src/Spryker/Client/ProductReview/ProductReviewClient.php
@@ -7,6 +7,7 @@
 
 namespace Spryker\Client\ProductReview;
 
+use Generated\Shared\Transfer\BulkProductReviewSearchRequestTransfer;
 use Generated\Shared\Transfer\ProductReviewRequestTransfer;
 use Generated\Shared\Transfer\ProductReviewSearchRequestTransfer;
 use Generated\Shared\Transfer\ProductReviewSummaryTransfer;

--- a/src/Spryker/Client/ProductReview/ProductReviewClientInterface.php
+++ b/src/Spryker/Client/ProductReview/ProductReviewClientInterface.php
@@ -87,10 +87,10 @@ interface ProductReviewClientInterface
      *
      * @api
      *
-     * @param \Generated\Shared\Transfer\ProductViewTransfer[] $productViewTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
      * @param \Generated\Shared\Transfer\BulkProductReviewSearchRequestTransfer $bulkProductReviewSearchRequestTransfer
      *
-     * @return \Generated\Shared\Transfer\ProductViewTransfer[]
+     * @return array<int, \Generated\Shared\Transfer\ProductViewTransfer>
      */
     public function expandProductViewBulkWithProductReviewData(
         array $productViewTransfers,

--- a/src/Spryker/Client/ProductReview/ProductReviewClientInterface.php
+++ b/src/Spryker/Client/ProductReview/ProductReviewClientInterface.php
@@ -7,6 +7,7 @@
 
 namespace Spryker\Client\ProductReview;
 
+use Generated\Shared\Transfer\BulkProductReviewSearchRequestTransfer;
 use Generated\Shared\Transfer\ProductReviewRequestTransfer;
 use Generated\Shared\Transfer\ProductReviewSearchRequestTransfer;
 use Generated\Shared\Transfer\ProductReviewSummaryTransfer;

--- a/src/Spryker/Client/ProductReview/ProductReviewClientInterface.php
+++ b/src/Spryker/Client/ProductReview/ProductReviewClientInterface.php
@@ -81,7 +81,8 @@ interface ProductReviewClientInterface
 
     /**
      * Specification:
-     *  - Expands product view data with product review summary data (average rating).
+     * - Expands product view data with product review summary data (average rating).
+     * - Expects `ProductViewTransfer.idProductAbstract` to be set.
      *
      * @api
      *

--- a/src/Spryker/Client/ProductReview/ProductViewExpander/ProductViewExpander.php
+++ b/src/Spryker/Client/ProductReview/ProductViewExpander/ProductViewExpander.php
@@ -8,6 +8,7 @@
 namespace Spryker\Client\ProductReview\ProductViewExpander;
 
 use Generated\Shared\Transfer\ProductReviewSearchRequestTransfer;
+use Generated\Shared\Transfer\ProductReviewSummaryTransfer;
 use Generated\Shared\Transfer\ProductViewTransfer;
 use Generated\Shared\Transfer\RatingAggregationTransfer;
 use Spryker\Client\ProductReview\Calculator\ProductReviewSummaryCalculatorInterface;
@@ -93,18 +94,60 @@ class ProductViewExpander implements ProductViewExpanderInterface
             return $productViewTransfers;
         }
 
-        foreach ($productsReviews[static::KEY_PRODUCT_BULK_AGGREGATION] as $productId => $productReviews) {
+        foreach ($productsReviews[static::KEY_PRODUCT_BULK_AGGREGATION] as $idProductAbstract => $productReviews) {
             if (empty($productReviews[static::KEY_RATING_AGGREGATION])) {
                 continue;
             }
 
-            if (isset($productViewTransfers[$productId])) {
-                $productReviewSummaryTransfer = $this->productReviewSummaryCalculator->calculate(
-                    $this->createRatingAggregationTransfer($productReviews)
-                );
-
-                $productViewTransfers[$productId]->setRating($productReviewSummaryTransfer);
+            $filteredProductViewTransfers = $this->filterProductViewTransfersByIdProductAbstract($productViewTransfers, $idProductAbstract);
+            if (!count($filteredProductViewTransfers)) {
+                continue;
             }
+
+            $productReviewSummaryTransfer = $this->productReviewSummaryCalculator->calculate(
+                $this->createRatingAggregationTransfer($productReviews)
+            );
+
+            $this->expandProductViewTransfersWithRating(
+                $filteredProductViewTransfers,
+                $productReviewSummaryTransfer
+            );
+        }
+
+        return $productViewTransfers;
+    }
+
+    /**
+     * @param array<int, \Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
+     * @param int $idProductAbstract
+     *
+     * @return list<\Generated\Shared\Transfer\ProductViewTransfer>
+     */
+    protected function filterProductViewTransfersByIdProductAbstract(array $productViewTransfers, int $idProductAbstract): array
+    {
+        $filteredProductViewTransfers = array_filter($productViewTransfers, function (ProductViewTransfer $productViewTransfer) use ($idProductAbstract) {
+            return $productViewTransfer->getIdProductAbstract() === $idProductAbstract;
+        });
+
+        if (count($filteredProductViewTransfers)) {
+            return $filteredProductViewTransfers;
+        }
+
+        return isset($productViewTransfers[$idProductAbstract]) ? [$productViewTransfers[$idProductAbstract]] : [];
+    }
+
+    /**
+     * @param list<\Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
+     * @param \Generated\Shared\Transfer\ProductReviewSummaryTransfer $productReviewSummaryTransfer
+     *
+     * @return list<\Generated\Shared\Transfer\ProductViewTransfer>
+     */
+    protected function expandProductViewTransfersWithRating(
+        array $productViewTransfers,
+        ProductReviewSummaryTransfer $productReviewSummaryTransfer
+    ): array {
+        foreach ($productViewTransfers as $productViewTransfer) {
+            $productViewTransfer->setRating($productReviewSummaryTransfer);
         }
 
         return $productViewTransfers;

--- a/src/Spryker/Client/ProductReview/ProductViewExpander/ProductViewExpander.php
+++ b/src/Spryker/Client/ProductReview/ProductViewExpander/ProductViewExpander.php
@@ -81,9 +81,9 @@ class ProductViewExpander implements ProductViewExpanderInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\ProductViewTransfer[] $productViewTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
      *
-     * @return \Generated\Shared\Transfer\ProductViewTransfer[]
+     * @return array<int, \Generated\Shared\Transfer\ProductViewTransfer>
      */
     public function expandProductViewsWithProductReviewData(
         array $productViewTransfers
@@ -121,10 +121,11 @@ class ProductViewExpander implements ProductViewExpanderInterface
      * @param array<int, \Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
      * @param int $idProductAbstract
      *
-     * @return list<\Generated\Shared\Transfer\ProductViewTransfer>
+     * @return array<int, \Generated\Shared\Transfer\ProductViewTransfer>
      */
     protected function filterProductViewTransfersByIdProductAbstract(array $productViewTransfers, int $idProductAbstract): array
     {
+        /** @var array<int, \Generated\Shared\Transfer\ProductViewTransfer> $filteredProductViewTransfers */
         $filteredProductViewTransfers = array_filter($productViewTransfers, function (ProductViewTransfer $productViewTransfer) use ($idProductAbstract) {
             return $productViewTransfer->getIdProductAbstract() === $idProductAbstract;
         });
@@ -137,10 +138,10 @@ class ProductViewExpander implements ProductViewExpanderInterface
     }
 
     /**
-     * @param list<\Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
      * @param \Generated\Shared\Transfer\ProductReviewSummaryTransfer $productReviewSummaryTransfer
      *
-     * @return list<\Generated\Shared\Transfer\ProductViewTransfer>
+     * @return array<int, \Generated\Shared\Transfer\ProductViewTransfer>
      */
     protected function expandProductViewTransfersWithRating(
         array $productViewTransfers,

--- a/src/Spryker/Client/ProductReview/ProductViewExpander/ProductViewExpanderInterface.php
+++ b/src/Spryker/Client/ProductReview/ProductViewExpander/ProductViewExpanderInterface.php
@@ -24,9 +24,9 @@ interface ProductViewExpanderInterface
     ): ProductViewTransfer;
 
     /**
-     * @param \Generated\Shared\Transfer\ProductViewTransfer[] $productViewTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductViewTransfer> $productViewTransfers
      *
-     * @return \Generated\Shared\Transfer\ProductViewTransfer[]
+     * @return array<int, \Generated\Shared\Transfer\ProductViewTransfer>
      */
     public function expandProductViewsWithProductReviewData(
         array $productViewTransfers

--- a/src/Spryker/Shared/ProductReview/Transfer/product_review.transfer.xml
+++ b/src/Spryker/Shared/ProductReview/Transfer/product_review.transfer.xml
@@ -64,6 +64,7 @@
 
     <transfer name="ProductView">
         <property name="rating" type="ProductReviewSummary"/>
+        <property name="idProductAbstract" type="int"/>
     </transfer>
 
     <transfer name="ProductReviewSummary">

--- a/tests/SprykerTest/Client/ProductReview/_support/ProductReviewClientTester.php
+++ b/tests/SprykerTest/Client/ProductReview/_support/ProductReviewClientTester.php
@@ -34,69 +34,30 @@ class ProductReviewClientTester extends Actor
     use _generated\ProductReviewClientTesterActions;
 
     /**
-     * @return int[][][][]
-     */
-    public function createClinetSearchMockResponse(): array
-    {
-        return [
-            'productAggregation' => [
-                1 => [
-                    'ratingAggregation' => [
-                        5 => 3,
-                        2 => 1,
-                    ],
-                ],
-                2 => [
-                    'ratingAggregation' => [
-                        5 => 3,
-                        1 => 10,
-                    ],
-                ],
-                3 => [
-                    'ratingAggregation' => [
-                        5 => 130,
-                        4 => 33,
-                        3 => 21,
-                        2 => 10,
-                        1 => 5,
-                    ],
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * @param int $id
+     * @param list<int> $productAbstractIds
      *
-     * @return \Generated\Shared\Transfer\ProductViewTransfer
+     * @return list<\Generated\Shared\Transfer\ProductViewTransfer>
      */
-    public function buildProductViewTranseferById(int $id): ProductViewTransfer
+    public function createProductViewTransfers(array $productAbstractIds): array
     {
-        $prodcutViewTransfer = new ProductViewTransfer();
-        $prodcutViewTransfer->setIdProductAbstract($id);
+        $productViewTransfers = [];
+        foreach ($productAbstractIds as $idProductAbstract) {
+            $productViewTransfer = (new ProductViewTransfer())->setIdProductAbstract($idProductAbstract);
+            $productViewTransfers[] = $productViewTransfer;
+        }
 
-        return $prodcutViewTransfer;
+        return $productViewTransfers;
     }
 
     /**
-     * @return \Generated\Shared\Transfer\ProductViewTransfer[]
-     */
-    public function createProductViews(): array
-    {
-        return [
-            1 => $this->buildProductViewTranseferById(1),
-            2 => $this->buildProductViewTranseferById(2),
-            3 => $this->buildProductViewTranseferById(3),
-        ];
-    }
-
-    /**
+     * @param list<int> $productAbstractIds
+     *
      * @return \Generated\Shared\Transfer\BulkProductReviewSearchRequestTransfer
      */
-    public function createBulkProductReviewSearchRequestTransfer(): BulkProductReviewSearchRequestTransfer
+    public function createBulkProductReviewSearchRequestTransfer(array $productAbstractIds): BulkProductReviewSearchRequestTransfer
     {
         $bulkProductReviewSearchRequestTransfer = new BulkProductReviewSearchRequestTransfer();
-        $bulkProductReviewSearchRequestTransfer->setProductAbstractIds(array_keys($this->createProductViews()));
+        $bulkProductReviewSearchRequestTransfer->setProductAbstractIds($productAbstractIds);
         $bulkProductReviewSearchRequestTransfer->setFilter(new FilterTransfer());
 
         return $bulkProductReviewSearchRequestTransfer;


### PR DESCRIPTION
Branch: backport/1.4.0
Ticket: https://spryker.atlassian.net/browse/CC-32183
Version: 1.4.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductReview         | minor                 |                       |

-----------------------------------------

#### Module ProductReview

##### Change log

Improvements

- Adjusted `ProductReviewClient::expandProductViewBulkWithProductReviewData()` to use product abstract IDs for filtering product views that are connected to reviews.
- Introduced `ProductView.idProductAbstract` transfer field.
